### PR TITLE
Modified find_centroids.py to detect input mask with colors 0,1,2 instead of black, red, blue

### DIFF
--- a/draw_mask.py
+++ b/draw_mask.py
@@ -8,6 +8,8 @@ global drawing, rdrawing, img
 #TODO: undo button?
 #TODO: name window
 
+####annotate_dir("images/datasets/bolts", "_dyn", "train", 5, 10)
+####annotate_img("test/142.png",150,7)
 #Set up callbacks for drawing circles on click and drag, bound to left and middle mouse 
 def draw_circle(event,x,y,flags,param):
     global mouseX,mouseY
@@ -75,14 +77,31 @@ def annotate_img(img_path, size1, size2) :
 
     #Make mask same colour as drawing and output binarised image
     train_labels = img[:,:,:3]
-    lower = np.array([254,0,0], dtype = "uint16")
-    upper = np.array([255,0,0], dtype = "uint16")
-    mask = cv2.inRange(train_labels, lower, upper)
-    mask[mask < 250] = 0
-    mask[mask != 0 ] = 1
- 
+    lower_blue = np.array([254,0,0], dtype = "uint16")
+    upper_blue = np.array([255,0,0], dtype = "uint16")
+    mask_blue = cv2.inRange(train_labels, lower_blue, upper_blue)
+    mask_blue[mask_blue < 250] = 0
+    #mask_blue[mask_blue != 0 ] = 255
+    mask_blue[mask_blue != 0 ] = 1
+
+##NEW
+    lower_red = np.array([0,0,254], dtype = "uint16")
+    upper_red = np.array([0,0,255], dtype = "uint16")
+    mask_red = cv2.inRange(train_labels, lower_red, upper_red)
+    mask_red[mask_red < 250] = 0
+    #mask_red[mask_red != 0 ] = 255  
+    mask_red[mask_red != 0 ] = 2
+    #Add the masks together to get array of pixel labels
+    mask = np.add(mask_red, mask_blue)
+    #mask = cv2.bitwise_or(mask_red,mask_blue)
+    print(np.unique(mask))
+ ##eND NEW
+
     #save label in code directory
-    cv2.imwrite('label.png', mask )
+    cv2.imwrite('label.png', mask)
+    cv2.imwrite('labelred.png', mask_red)
+    cv2.imwrite('labelblue.png',mask_blue)
+    print(mask_red)
     cv2.destroyWindow('image')
     return
             
@@ -132,14 +151,16 @@ def annotate_dir(img_dir, dataset, subset, size1, size2) :
         upper_blue = np.array([255,0,0], dtype = "uint16")
         mask_blue = cv2.inRange(train_labels, lower_blue, upper_blue)
         mask_blue[mask_blue < 250] = 0
+        #mask_blue[mask_blue != 0 ] = 255
         mask_blue[mask_blue != 0 ] = 1
         
         lower_red = np.array([0,0,254], dtype = "uint16")
         upper_red = np.array([0,0,255], dtype = "uint16")
         mask_red = cv2.inRange(train_labels, lower_red, upper_red)
         mask_red[mask_red < 250] = 0
-        mask_red[mask_red != 0 ] = 2  
-        
+        #mask_red[mask_red != 0 ] = 255  
+        mask_red[mask_red != 0 ] = 2
+
         #Add the masks together to get array of pixel labels
         mask = np.add(mask_red, mask_blue)
         print(np.unique(mask))

--- a/find_centroids.py
+++ b/find_centroids.py
@@ -3,26 +3,37 @@ import numpy as np
 from skimage import color, img_as_ubyte
 import os, sys
 
-
 def find_centroids(img_path) :
+
     img = cv2.imread(img_path)
 
-    #Set up separate masks for bolts and pmts and an output image
     train_labels = img
-    lower_pmts = np.array([254, 0, 0], dtype = "uint16")
-    upper_pmts = np.array([255,0,0], dtype = "uint16")
-    lower_bolts = np.array([0, 0, 254], dtype = "uint16")
-    upper_bolts = np.array([0,0,255], dtype = "uint16")
+
+    lower_pmts = np.array([1, 1, 1], dtype = "uint16")
+    upper_pmts = np.array([1,1,1], dtype = "uint16")
+    lower_bolts = np.array([2, 2, 2], dtype = "uint16")
+    upper_bolts = np.array([2,2,2], dtype = "uint16")
 
     pmts_gray = cv2.inRange(train_labels, lower_pmts, upper_pmts)
     bolts_gray = cv2.inRange(train_labels, lower_bolts, upper_bolts)
     img = cv2.cvtColor(bolts_gray,cv2.COLOR_GRAY2BGR)
+    cv2.imwrite("pmts_gray--4.png",pmts_gray)
+    cv2.imwrite("bolts_gray--4.png",bolts_gray)
+    cv2.imwrite("img--4.png",img)
+
+
+
+
+
+
+
 
     #print('images made')
 
     #Calls HoughCircles() to find multiple PMTs in an image
 
     #Outpts list of circle parameters
+    ################################################################
     def find_pmts(gray_img) :
         out = []
         edges = cv2.Canny(gray_img,0,100)
@@ -30,16 +41,23 @@ def find_centroids(img_path) :
                                minDist=200,
                                param1=100,
                                param2=20,
-                               minRadius=150,
+                               minRadius=100,
                                 maxRadius=200
                               )
         #print(circles)
+
+        ##Error over here vvvv, because circles is empty.
         circles = np.uint16(np.around(circles))
         img2 = cv2.cvtColor(edges,cv2.COLOR_GRAY2BGR)
 
 
         return circles
-    
+    ################################################################
+
+
+
+
+    ################################################################
 
     #Find centroids of bolts near edge of circles in find_pmts() using findContours()
 
@@ -76,12 +94,17 @@ def find_centroids(img_path) :
             else:
                 continue
         return out
+    ################################################################
+
+
+
+
 
     #find circles in image
     circles = find_pmts(pmts_gray)
     bolt_centres = []
 
-    #loop over circles and find bolts, end up with list of circles, each a  list of bolts (no circle parameters are saved )
+    #loop over circles and find bolts, end up with list of circles, each a list of bolts (no circle parameters are saved )
     for i in circles[0, :] :
         bolt_ring = ret_centres(bolts_gray, i)
         bolt_centres.append(bolt_ring)
@@ -91,12 +114,14 @@ def find_centroids(img_path) :
         cv2.circle(img,(i[0],i[1]),2,(0,255,0),3)
 
 
-
-
     #draw bolt locations
     for i in bolt_centres :
         for j in i :
             cv2.circle(img, (j[1], j[0]), 5, (0,0,255), -1)
 
-    cv2.imwrite('/home/dm3315/Documents/SK/PMT_learning/images/datasets/bolts_pmt/output/output/cont_out.png', img )
+
+    print(bolt_centres)
+    print(circles)
+    print("SAVING")
+    cv2.imwrite('out.png', img )
  


### PR DESCRIPTION
`find_centroids.py` now takes an input mask where:
`(0,0,0)` is the background-color
`(1,1,1)` is the color of the PMT labels
`(2,2,2)` is the color of the bolt labels

Updated annotate_img to include both labeling colors (`(1,1,1)` and `(2,2,2)`) 
annotate_img was only making a mask with a single color. 
(will work on adapting my version of this code to use instead).
